### PR TITLE
fix scaling on an unmounted node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-avatar",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Universal React avatar component makes it possible to generate avatars based on user information.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/avatar.js
+++ b/src/avatar.js
@@ -175,6 +175,9 @@ function createAvatarComponent({ sources = [] }) {
                 return;
 
             const spanNode = node.parentNode;
+            if (!spanNode)
+                return;
+
             const tableNode = spanNode.parentNode;
 
             const {


### PR DESCRIPTION
### What happens:
1. when the element width/height is 0 (in this case caused by the `display-none` on the parent element)  it loops `_scaleTextNode`: https://github.com/Sitebase/react-avatar/blob/master/src/avatar.js#L191-L195
2. when you change value – the element key also changes (causing unmount): https://github.com/Sitebase/react-avatar/blob/master/src/avatar.js#L276-L279
3. when the element is unmounted (not in the dom), it does not have a parent element.
4. this node exists, but parentNode is null: https://github.com/Sitebase/react-avatar/blob/master/src/avatar.js#L177

### Example: https://codesandbox.io/s/example-for-react-avatar-editor-forked-mxnjk?file=/index.js
### How to reproduce:
1. click change content.
2. click hide.
3. click change content 💥

### Fixes: #164
