### PR TITLE
[build] use new babel tools to optimize dependencies and polyfills

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,16 +3,14 @@
 const { BABEL_MODULES = false } = process.env;
 
 module.exports = {
-    "presets": [
-        ["@babel/preset-env", {
-            "targets": "> 0.25%, not dead",
-            "modules": BABEL_MODULES,
-            "useBuiltIns": "usage",
-            "corejs": { version: 3 }
-        }],
-        "@babel/preset-react"
+    targets: '> 0.25%, not dead',
+    presets: [
+        [ '@babel/preset-env', { modules: BABEL_MODULES } ],
+        '@babel/preset-react'
     ],
-    "plugins": [
-        "@babel/plugin-proposal-class-properties"
+    plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-transform-runtime',
+        [ 'polyfill-corejs3', { method: 'usage-pure' } ],
     ]
-}
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   ],
   "homepage": "https://www.sitebase.be/react-avatar/",
   "peerDependencies": {
+    "@babel/runtime": ">=7",
+    "core-js-pure": ">=3",
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
     "prop-types": "^15.0.0 || ^16.0.0"
   },
@@ -47,11 +49,15 @@
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
     "@babel/plugin-proposal-class-properties": "^7.7.4",
+    "@babel/plugin-transform-runtime": "^7.16.0",
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
+    "@babel/runtime": "^7.16.0",
     "@types/react": "^16.0.0",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
+    "babel-plugin-polyfill-corejs3": "^0.3.0",
+    "core-js-pure": "^3.19.1",
     "eslint": "^6.8.0",
     "eslint-loader": "^3.0.3",
     "eslint-plugin-react": "^7.17.0",
@@ -66,7 +72,6 @@
     "webpack-dev-server": "^3.10.1"
   },
   "dependencies": {
-    "core-js": "^3.6.1",
     "is-retina": "^1.0.3",
     "md5": "^2.0.0"
   }


### PR DESCRIPTION
- `@babel/plugin-transform-runtime` to turn the babel syntax helpers into require statements. This way the helpers are not duplicated in every file and can also be shared when react-avatar is installed in a larger project with other libraries that use the transform runtime.
- `babel-plugin-polyfill-corejs3` so polyfills use `core-js-pure` which doesn't pollute the global namespace and only polyfills the things that are needed based on the targets config