### PR TITLE
Accessibility fix for default color

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,14 +40,15 @@ function fetchJSONP(url, successCb, errorCb) {
     };
 }
 
+// https://webaim.org/resources/contrastchecker/
 export
 const defaultColors = [
-    '#d73d32',
+    '#A62A21',
     '#7e3794',
-    '#4285f4',
-    '#67ae3f',
-    '#d61a7f',
-    '#ff4080'
+    '#0B51C1',
+    '#3A6024',
+    '#A81563',
+    '#B3003C'
 ];
 
 // https://regex101.com/r/YEsPER/1


### PR DESCRIPTION
The original default color does not have enough contrast (4.5) with white text color.
I have updated it to compatible with WCAG AA/AAA standard (4.5:1 and 7.5:1)

#d73d32 --> #A62A21
#4285f4 --> #0B51C1
#67ae3f --> #3A6024
#d61a7f --> #A81563
#ff4080 --> #B3003C

Thanks a lot ! 