### PR TITLE
React 18 add children to props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 export interface ReactAvatarProps {
+    children?: React.ReactNode;
     /**
      * Name of the CSS class you want to add to this component alongside the default sb-avatar.
      */


### PR DESCRIPTION
React 18 [removed](https://stackoverflow.com/questions/71788254/react-18-typescript-children-fc/71809927#71809927) default children props. 
This adds children props to adjust typings for the library to work with react 18